### PR TITLE
Issue#119

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -329,6 +329,9 @@ if (typeof brutusin === "undefined") {
                 input.title = s.description;
                 input.placeholder = s.description;
             }
+            if (s.class) {
+                input.className = s.class;
+            }
 //        if (s.pattern) {
 //            input.pattern = s.pattern;
 //        }
@@ -395,6 +398,9 @@ if (typeof brutusin === "undefined") {
             };
             input.schema = schemaId;
             input.id = getInputId();
+            if (s.class) {
+                input.className = s.class;
+            }
             inputCounter++;
             if (s.description) {
                 input.title = s.description;

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -277,6 +277,14 @@ if (typeof brutusin === "undefined") {
                                 return BrutusinForms.messages["maxLength"].format(s.maxLength);
                             }
                         }
+                        //Issue#90
+                        //Add a default regex pattern matching for email validation, or else user could use
+                        //the `pattern` field for their own custom regex pattern
+                        if (!s.pattern && s.format === "email") {
+                            if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
+                                return BrutusinForms.messages["email"];
+                            }
+                        }
                     }
                     if (value !== null && !isNaN(value)) {
                         if (s.multipleOf && value % s.multipleOf !== 0) {


### PR DESCRIPTION
**Issue#119: Add custom class name support**

Description: User requests to have self-defined class name in the schema.

Pic before change:
 
![image](https://github.com/saicheck2233/json-forms/assets/137158566/c30e89ec-df4d-4381-b8f9-2606f44e36a8)
_“custom-class” is added into the schema field `class` but input field does not show up because it wasn’t supported yet._

Pic after change:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/3715832f-60c3-4d10-ac6f-8dee94f9ee0d)
_Now “custom-class” is added into the class field in the HTML attributes._
