### PR TITLE
issue#90: email validation does not work

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -277,6 +277,13 @@ if (typeof brutusin === "undefined") {
                                 return BrutusinForms.messages["maxLength"].format(s.maxLength);
                             }
                         }
+                        //Add a default regex pattern matching for email validation, or else user could use
+                        //the `pattern` field for their own custom regex pattern
+                        if (!s.pattern && s.format === "email") {
+                            if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
+                                return BrutusinForms.messages["email"];
+                            }
+                        }
                     }
                     if (value !== null && !isNaN(value)) {
                         if (s.multipleOf && value % s.multipleOf !== 0) {

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -76,6 +76,7 @@ if (typeof brutusin === "undefined") {
         "exclusiveMaximum": "Value must be **lower than** `{0}`",
         "minProperties": "At least `{0}` properties are required",
         "maxProperties": "At most `{0}` properties are allowed",
+        "email": "The email must at least consists an asterisk (@), following by a domain name with a dot (.)",
         "uniqueItems": "Array items must be unique",
         "addItem": "Add item",
         "true": "True",


### PR DESCRIPTION
**Issue: Email Validation does not work**

Description: When the input field is set to email, and an invalid email format is key in, it is able to pass the validation check.

Pic before change:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/7f5144f1-de50-47e8-a148-9b4a1fad118e)

Pic after change:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/b5ee838e-6288-4061-8049-c965b19533d3)
_Invalid email format_

![image](https://github.com/saicheck2233/json-forms/assets/137158566/ad2788cc-9cfd-43b9-9d65-26e948759591)
_Valid email format return validation succeed_