### PR TITLE
issue#138: empty string not returned

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -874,6 +874,10 @@ if (typeof brutusin === "undefined") {
                             }
                         }
                         var value = removeEmptiesAndNulls(object[prop], ss);
+                        //Check if user assign an empty String in the default field, if true return empty string instead of null
+                        if (ss.default == "" && value === null) {
+                            value = "";
+                        }
                         if (value !== null) {
                             clone[prop] = value;
                             nonEmpty = true;


### PR DESCRIPTION
**Issue#138: Nulls are returned instead of empty strings**

Link: [Issue#138](https://github.com/brutusin/json-forms/issues/138)

Description: When new string elements are added and they are not filled with any data, nulls are returned instead. However it should be empty strings according to the schema.
![image](https://github.com/saicheck2233/json-forms/assets/137158566/f97e66da-b068-4313-9f86-dbb01c31b5bb)

Pic before changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/a23e021d-9936-441d-a29d-87b448042663)
_JSON return null_

Pic after changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/79af81a9-d2e5-44cc-8dfe-36e79ebf065f)
_JSON now return ""_
