### PR TITLE
issue#103

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1200,6 +1200,9 @@ if (typeof brutusin === "undefined") {
                 if (!value) {
                     if (typeof initialValue !== "undefined" && initialValue !== null) {
                         value = getInitialValue(id);
+                        if (value === null && typeof s.default !== "undefined") {
+                            value = s.default;
+                        }
                     } else {
                         value = s.default;
                     }


### PR DESCRIPTION
**Issue#103: Adding new item to an array doesnt show default values when Initial Data is passed**

Link: [Issue#103](https://github.com/brutusin/json-forms/issues/103) 

Description: When initial data is passed, the form with array items gets loaded properly as per the initial data passed. However, when a new item is added through **Add item** button, the form elements are not loaded with default data provided in the schema.
This error can be simulated using following schema:
```
{
  "$schema": "http://json-schema.org/draft-03/schema#",
  "type": "object",
  "properties": {
    "sorts": {
      "type": "array",
      "title": "Sorting",
      "items": {
        "type": "object",
        "properties": {
          "fieldName": {
            "type": "string",
            "title": "Field name"
          },
          "ascending": {
            "type": "boolean",
            "title": "Ascending",
            "default": true
          }
        }
      }
    }
  }
}
```
Initial data schema used:
```
{
  "sorts": [
    {
      "fieldName": "test",
      "ascending": true
    }
  ]
}
```

Pic before changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/b6f178ec-615f-4b9f-89fc-fc4b072ee2a0)
_The ascending field does not generate the default value defined in the schema, which is True._

Pic after changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/4abbd4cf-5a93-4fa7-9e28-0240618779da)
_Now the Ascending field would have the default value True populated._
