### PR TITLE
issue#115: add password field format

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -228,6 +228,8 @@ if (typeof brutusin === "undefined") {
                     input.type = "time";
                 } else if (s.format === "email") {
                     input.type = "email";
+                } else if (s.format === "password") {
+                    input.type = "password";
                 } else if (s.format === "text") {
                     input = document.createElement("textarea");
                 } else {


### PR DESCRIPTION
**Issue#115: Support for type 'password'**

Link: [Issue#115](https://github.com/brutusin/json-forms/issues/115)

Description: Add a new format for password field

Pic before changes:
![image](https://github.com/brutusin/json-forms/assets/137158566/b3c52ca0-e74e-436e-a990-58722628f0e4)
_Password field does not masked the password typed_

Pic after changes:
![image](https://github.com/brutusin/json-forms/assets/137158566/44b3843e-cc86-4694-be0a-081d098ffcb6)
_Password field now masked the password type_

Remark:
Another way of doing this without the code changes on the JSON form library is add a format decorator in your own code. This would require to import the `brutusin-json-forms-boostrap.js`.

`BrutusinForms.bootstrap.addFormatDecorator("password", "password");`

But since this changes is applied, the above method is not needed anymore.
