### PR TITLE
issue#95&#108

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -252,9 +252,15 @@ if (typeof brutusin === "undefined") {
                             if (parentSchema && parentSchema.type === "object") {
                                 if (parentSchema.required) {
                                     return BrutusinForms.messages["required"];
+                                } else if (parentSchema.requiredProperties) {
+                                    for (var i = 0; i < parentSchema.requiredProperties.length; i++) {
+                                        if (parentSchema.requiredProperties[i] === s.$id.substring(2)) {
+                                            return BrutusinForms.messages["required"];
+                                        }
+                                    }
                                 } else {
                                     for (var prop in parentObject) {
-                                        if (parentObject[prop] !== null) {
+                                        if (parentObject[prop] === null) {
                                             return BrutusinForms.messages["required"];
                                         }
                                     }


### PR DESCRIPTION
**Issue#95 & Issue#108: Validation passed even though required field is empty**

Description: Field is required and it is empty but then validation still shows succeeded for the JSON schema below
```
{
	"title": "Person",
	"type": "object",
	"properties": {
		"firstName": {
			"type": "string"
		},
		"lastName": {
			"type": "string"
		},
		"age": {
			"description": "Age in years",
			"type": "integer",
			"minimum": 0
		}
	},
	"required": [
		"firstName",
		"lastName"
	]
}
```

Pic before changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/9a90d11c-7bbb-4418-b766-050ad41b627f)
The validation passed eventhough the field `firstName` and `lastName` are required

Pic after changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/475b725c-e88b-451d-8507-a77bdfa850c4)
The validation did not pass as the field `firstName` and `lastName` are required and cannot be empty