### PR TITLE
issue#37: add support for radio button

### DIFF
--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -64,7 +64,12 @@ form.brutusin-form table, form.brutusin-form input, form.brutusin-form select, f
     width: 100% !important;
     min-width: 80px;
 }
-form.brutusin-form input[type=checkbox]{
+
+form.brutusin-form input[type=radio] {
+    margin: 0 15px 0 10px;
+}
+
+form.brutusin-form input[type=checkbox], form.brutusin-form input[type=radio] {
     width: auto !important;
     min-width: auto !important;
 }

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -33,7 +33,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.addDecorator(function (element, schema) {
         if (element.tagName) {
             var tagName = element.tagName.toLowerCase();
-            if (tagName === "input" && element.type !== "checkbox" || tagName === "textarea") {
+            if (tagName === "input" && (element.type !== "checkbox" && element.type !== "radio") || tagName === "textarea") {
                 element.className += " form-control";
             } else if (tagName === "select") {
                 element.className += " chosen-select form-control";

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -364,7 +364,29 @@ if (typeof brutusin === "undefined") {
             var schemaId = getSchemaId(id);
             var s = getSchema(schemaId);
             var input;
-            if (s.required) {
+            if (s.format === "radio") {
+                input = document.createElement("div");
+                for (var i = 0; i < s.enum.length; i++) {
+                    var radioInput = document.createElement("input");
+                    radioInput.type = "radio";
+                    radioInput.name = s.$id.substring(2);
+                    radioInput.value = s.enum[i];
+                    radioInput.id = s.enum[i];
+                    var label = document.createElement("label");
+                    label.htmlFor = s.enum[i];
+                    var labelText = document.createTextNode(s.enum[i]);
+                    appendChild(label, labelText);
+                    if (value && s.enum[i] === value) {
+                        radioInput.checked = true;
+                    }
+                    if (s.readOnly) {
+                        radioInput.disabled = true;
+                    }
+                    appendChild(input, label);
+                    appendChild(input, radioInput, s);
+                }
+            }
+            else if (s.required) {
                 input = document.createElement("input");
                 input.type = "checkbox";
                 if (value === true || value !== false && s.default) {


### PR DESCRIPTION
Issue#37: Support for radio button inputs

Link: [Issue#37](https://github.com/brutusin/json-forms/issues/37) 

Description: Add support for radio button inputs, below is the schema used for generating a radio button. `format:radio` and `enum` is needed for generating radio buttons.
```
{
    "$schema": "http://json-schema.org/draft-03/schema#",
    "type": "object",
    "properties": {
        "pageSize": {
            "type": "boolean",
            "format": "radio",
            "title": "Page size",
            "description": "Number of records per page",
            "enum": [
                10,
                25,
                50,
                100
            ]
        }
    }
}
```

Pic before changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/24e1f909-0d2e-4f82-8610-ae921309da47)
_Before having radio button support, it falls back to dropdown selection._

Pic after changes:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/c7c101d1-6836-49de-b2d6-4025a4e8f066)
_After radio button format is implemented, now it is showing radio button._