### PR TITLE
issue#121: remove `eval` func

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1270,13 +1270,24 @@ if (typeof brutusin === "undefined") {
         }
 
         function getInitialValue(id) {
-            var ret;
-            try {
-                eval("ret = initialValue" + id.substring(1));
-            } catch (e) {
-                ret = null;
+            var fields = id.substring(2).split('.');
+            var initialValueClone = initialValue;
+            for(var i = 0; i < fields.length; i++) {
+                var field = fields[i];
+                if (field != "") {
+                    if (field.substring(field.length - 1) === "]") {
+                        //Get the index from the array in the field
+                        var arrayIndex = parseInt(field.substring(field.lastIndexOf("[") + 1, field.length - 1));
+                        //Substring off the square bracket from the field
+                        field = field.substring(0, field.lastIndexOf("["));
+                        initialValueClone = initialValueClone[field][arrayIndex];
+                    } else {
+                        initialValueClone = initialValueClone[field];
+                    }
+                }
             }
-            return ret;
+
+            return initialValueClone;
         }
 
         function getValue(schema, input) {


### PR DESCRIPTION
Link: [Issue#121](https://github.com/brutusin/json-forms/issues/121)

Description: The script uses the command `eval`. The usage of the `eval` command collides with Content-Security-Policies. Those usually deny this command and will block of the data insertation. Allowing this command will allow it everywhere and contradicts the purpose of CSP.
Furthermore, `eval` poses a security risk where malicious code could be injected and executed. So removing `eval` and replace with another workaround is needed.

Note: No picture to screenshot as it only happens in the backend.
