### PR TITLE
Issue#129: Clean data after onChange between oneOf

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -897,9 +897,9 @@ if (typeof brutusin === "undefined") {
                         }
                         var value = removeEmptiesAndNulls(object[prop], ss);
                         //Check if user assign an empty String in the default field, if true return empty string instead of null
-                        if (ss.default == "" && value === null) {
-                            value = "";
-                        }
+                            if (ss.default == "" && value === null) {
+                                value = "";
+                            }
                         if (value !== null) {
                             clone[prop] = value;
                             nonEmpty = true;
@@ -1215,6 +1215,10 @@ if (typeof brutusin === "undefined") {
             renderInfoMap[schemaId].value = value;
             clear(titleContainer);
             clear(container);
+            if (s === undefined) {
+                data = new Object();
+                return;
+            }
             //console.log(id,s,value);
             var r = renderers[s.type];
             if (r && !s.dependsOn) {


### PR DESCRIPTION
**Link:** [Issue#129](https://github.com/brutusin/json-forms/issues/129)

**Description:** When you select one of the dropdown from the oneOf2, key in some value and select the default empty value in the dropdown, the value is still saved in the container.
For example, select [An object] from the oneOf example and then select []. When you click getData(), the values are still stored in the container.
This kind of situation will mismatch the function getData().
For example select [A multiple of 3] and fill with number 3. The getData() will get the value 3.
However, when you select [] and repeat the function getData(), it will still get the value 3.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/fc5d59a5-a949-4545-9ddf-ace0a53d1086)
_Select “A multiple of 3” and key in a number, clicking `getData()` it would return the value of it._

![image](https://github.com/saicheck2233/json-forms/assets/137158566/e7ae3bd5-af90-4c8f-a894-c01f6c879c20)
_Select the empty selection and click `getData()`, it would still return the value “3”._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/0680b852-efb7-417f-ba83-f32a29169a6b)
_Select “A multiple of 3” and key in a number, clicking `getData()` it would return the value of it._

![image](https://github.com/saicheck2233/json-forms/assets/137158566/af7ea8d4-ba6f-4f6e-9d67-91b6bfa6ec73)
_Select the empty selection and click `getData()` will now show null._
