### PR TITLE
bug: getData() won’t display on oneOf schema

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -919,8 +919,10 @@ if (typeof brutusin === "undefined") {
                         }
                         var value = removeEmptiesAndNulls(object[prop], ss);
                         //Check if user assign an empty String in the default field, if true return empty string instead of null
-                        if (ss.default == "" && value === null) {
-                            value = "";
+                        if (ss !== null) {
+                            if (ss.default == "" && value === null) {
+                                value = "";
+                            }
                         }
                         if (value !== null) {
                             clone[prop] = value;


### PR DESCRIPTION
**Description:** When there is an object type with properties in the oneOf schema, and I key in any data, if I click on `getData()` button, it won’t display the data out. Below is the schema being used:
```
{
    "$schema": "http://json-schema.org/draft-03/schema#",
    "oneOf": [
        {
            "title": "An object",
            "type": "object",
            "properties": {
                "p1": {
                    "type": "string",
                    "required": true,
                    "title": "A required string"
                },
                "p2": {
                    "type": "boolean",
                    "title": "A boolean"
                }
            }
        }
    ]
}
```

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/3547e217-a1f0-42fa-87e8-6a826e3765c9)
_When the `getData()` button is being clicked on, there is no popout box showing the value._


**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/a59ca096-70ad-41d6-95f5-2714aced3eb6)
_Now the popout box would display the data after the `getData()` button is clicked._