### PR TITLE
Issue#59: Remove colon from the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,13 @@
         <script src="//rawgit.com/brutusin/json-forms/master/dist/js/brutusin-json-forms-bootstrap.min.js"></script>
         <script lang="javascript">
             var BrutusinForms = brutusin["json-forms"];
-            BrutusinForms.bootstrap.addFormatDecorator("inputstream", "file", "glyphicon-search", function (element) {
+            BrutusinForms.bootstrap.addFormatDecorator("inputstream", "file", "glyphicon-search", null, function (element) {
                 alert("user callback on element " + element)
             });
             BrutusinForms.bootstrap.addFormatDecorator("color", "color");
             BrutusinForms.bootstrap.addFormatDecorator("date", "date");
+            //Title decorator
+            BrutusinForms.bootstrap.addFormatDecorator(null, null, null, ":");
             var codeMirrors = new Object();
             var input = new Object();
             var inputString = new Object();

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -124,7 +124,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     });
     BrutusinForms.bootstrap = new Object();
 // helper button for string (with format) fields
-    BrutusinForms.bootstrap.addFormatDecorator = function (format, inputType, glyphicon, cb) {
+    BrutusinForms.bootstrap.addFormatDecorator = function (format, inputType, glyphicon, titleDecorator, cb) {
         BrutusinForms.addDecorator(function (element, schema) {
             if (element.tagName) {
                 var tagName = element.tagName.toLowerCase();
@@ -154,6 +154,13 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                         };
                         td.appendChild(searchButton);
                     }
+                }
+            }
+
+            if (element instanceof Text) {
+                var tagName = element.parentElement.tagName.toLowerCase();
+                if (tagName === "label" && titleDecorator) {
+                    element.textContent = element.textContent + titleDecorator;
                 }
             }
         });

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1176,7 +1176,7 @@ if (typeof brutusin === "undefined") {
                     if (schema.type !== "any" && schema.type !== "object" && schema.type !== "array") {
                         titleLabel.htmlFor = getInputId();
                     }
-                    var titleNode = document.createTextNode(title + ":");
+                    var titleNode = document.createTextNode(title);
                     appendChild(titleLabel, titleNode, schema);
                     if (schema.description) {
                         titleLabel.title = schema.description;


### PR DESCRIPTION
**Link**: [Issue#59](https://github.com/brutusin/json-forms/issues/59)

**Description**: The colon on the title should not be there. User can choose to add a colon in his decorator. To have own custom decorator, user needs to add this piece of code into their webpage:
` BrutusinForms.bootstrap.addFormatDecorator(null, null, null, "-");`
The last parameter is the title decorator.

Pic before **changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/5174c42f-cb0d-4196-b1af-04e29a9c0e22)
_There is a hardcoded colon (:) at the title_

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/b5a02c7a-a510-4e53-9d9d-917887e69be6)
_If we don’t add the `addFormatDecorator()` function, the title won't have any separator_

![image](https://github.com/saicheck2233/json-forms/assets/137158566/fcff8434-424f-4704-8d86-648c7a814cd4)
_If we add the `addFormatDecorator()` function with “-“_