### PR TITLE
Enhancement: Add support for checkbox input

### DIFF
--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -65,7 +65,7 @@ form.brutusin-form table, form.brutusin-form input, form.brutusin-form select, f
     min-width: 80px;
 }
 
-form.brutusin-form input[type=radio] {
+form.brutusin-form input[type=radio], form.brutusin-form input[type=checkbox] {
     margin: 0 15px 0 10px;
 }
 

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -386,6 +386,28 @@ if (typeof brutusin === "undefined") {
                     appendChild(input, radioInput, s);
                 }
             }
+            else if (s.format === "checkbox") {
+                input = document.createElement("div");
+                for (var i = 0; i < s.enum.length; i++) {
+                    checkbox = document.createElement("input");
+                    checkbox.type = "checkbox";
+                    checkbox.name = s.enum[i];
+                    checkbox.value = s.enum[i];
+
+                    var label = document.createElement("label");
+                    label.htmlFor = s.enum[i];
+                    var labelText = document.createTextNode(s.enum[i]);
+                    appendChild(label, labelText);
+                    if (value && s.enum[i] === value) {
+                        checkbox.checked = true;
+                    }
+                    if (s.readOnly) {
+                        checkbox.disabled = true;
+                    }
+                    appendChild(input, label);
+                    appendChild(input, checkbox, s);
+                }
+            }
             else if (s.required) {
                 input = document.createElement("input");
                 input.type = "checkbox";


### PR DESCRIPTION
**Description**: Add support for checkbox inputs, below is the schema used for generating a checkbox. format:checkbox and enum is needed for generating checkboxes.
```
{
    "$schema": "http://json-schema.org/draft-03/schema#",
    "type": "object",
    "properties": {
        "radio1": {
            "type": "boolean",
            "format": "checkbox",
            "title": "Animal",
            "required": true,
            "enum": [
                "Dog",
                "Cat",
                "Bird"
            ]
        }
    }
}
```

**Changes**:
![image](https://github.com/brutusin/json-forms/assets/137158566/5bf5942b-042f-4dda-bf58-73e57d137b50)
_Schema needed to generate a form with checkboxes._
 
![image](https://github.com/brutusin/json-forms/assets/137158566/9ebef0b4-61fb-40a3-b0e5-771bd60d6bca)
_Generated form with checkboxes._
