### PR TITLE
Enhancement: Add checkbox example into UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,11 +114,11 @@
                     null,
                     null,
                     "Required properties supported in both v3 and v4+ spec formats. Last one format takes preference. More info [here](https://github.com/brutusin/json-forms/issues/56)"],
-                ["Radio button",
-                    {"$schema": "http://json-schema.org/draft-03/schema#", "type": "object", "properties": {"radio1": {"type": "boolean","format": "radio","title": "Animal", "required": true, "enum": ["Dog", "Cat", "Bird"]}}},
+                ["Radio button and checkbox",
+                {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"radio1":{"type":"boolean","format":"radio","title":"Animal","required":true,"enum":["Dog","Cat","Bird"]},"checkbox":{"type":"boolean","format":"checkbox","title":"Transportation","required":true,"enum":["Vehicle","Airplane","Cruise"]}}},
                     null,
                     null,
-                    "Boolean supporting radio type. Must define `format` and `enum` fields."]
+                    "Boolean supporting radio and checkbox type. Must define `format` and `enum` fields."]
             ];
 
             var selectedTab = "schema";


### PR DESCRIPTION
**Description**: Add checkbox example together with radio example into UI with the schema as below:
```
"checkbox": {
            "type": "boolean",
            "format": "checkbox",
            "title": "Transportation",
            "required": true,
            "enum": [
                "Vehicle",
                "Airplane",
                "Cruise"
            ]
        }
```

**Changes**:
 
![image](https://github.com/brutusin/json-forms/assets/137158566/4e7f894a-9bd2-47c2-86fc-b2bd5fe2c6f2)
_The example schema use to generate radio button and checkbox._
 
![image](https://github.com/brutusin/json-forms/assets/137158566/9fa5e19b-66fc-4e7f-aaa7-963fac761c3a)
_The generated form with radio button and checkbox._
