### PR TITLE
Enhancement: Add URL input type

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -77,6 +77,7 @@ if (typeof brutusin === "undefined") {
         "minProperties": "At least `{0}` properties are required",
         "maxProperties": "At most `{0}` properties are allowed",
         "email": "The email must at least consists an asterisk (@), following by a domain name with a dot (.)",
+        "url": "The URL provided is not a valid URL.",
         "uniqueItems": "Array items must be unique",
         "addItem": "Add item",
         "true": "True",
@@ -231,6 +232,8 @@ if (typeof brutusin === "undefined") {
                     input.type = "email";
                 } else if (s.format === "password") {
                     input.type = "password";
+                } else if (s.format === "url") {
+                    input.type = "url";
                 } else if (s.format === "text") {
                     input = document.createElement("textarea");
                 } else {
@@ -291,6 +294,12 @@ if (typeof brutusin === "undefined") {
                         if (!s.pattern && s.format === "email") {
                             if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
                                 return BrutusinForms.messages["email"];
+                            }
+                        }
+
+                        if (!s.pattern && s.format === "url") {
+                            if (!value.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)) {
+                                return BrutusinForms.messages["url"];
                             }
                         }
                     }


### PR DESCRIPTION
**Description**: Add URL input type with validation. Below is the schema used for generating the URL input.
```
{
  "$schema": "http://json-schema.org/draft-03/schema#",
  "type": "object",
  "properties": {
    "s1": {
      "type": "string",
      "title": "An URL input",
      "format": "url",
      "description": "Example: www.domain.com"
    }
  }
}
```
Custom validation pattern is also supported if user does not want to use the default pattern validation.

**Changes:** 
![image](https://github.com/brutusin/json-forms/assets/137158566/f82ba07e-f4bc-4a1f-b148-f69b2dcea3d2)
_A generated form with URL type input._
 
![image](https://github.com/brutusin/json-forms/assets/137158566/5eebfdba-12e0-40d9-83a4-939dc15bbbc6)
_Form would throws validation error if the value given is not a valid URL._
 
![image](https://github.com/brutusin/json-forms/assets/137158566/6ec79aed-8536-4742-8cb8-f21fc07003b9)
_Validation passed if a valid URL is provided._
