### PR TITLE
Enhancement: Add getData() support for checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,10 +117,10 @@
                     null,
                     "Required properties supported in both v3 and v4+ spec formats. Last one format takes preference. More info [here](https://github.com/brutusin/json-forms/issues/56)"],
                 ["Radio button and checkbox",
-                {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"radio1":{"type":"boolean","format":"radio","title":"Animal","required":true,"enum":["Dog","Cat","Bird"]},"checkbox":{"type":"boolean","format":"checkbox","title":"Transportation","required":true,"enum":["Vehicle","Airplane","Cruise"]}}},
+                    {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"radio1":{"type":"boolean","format":"radio","title":"Animal","required":true,"enum":["Dog","Cat","Bird"]},"checkbox":{"type":"boolean","format":"checkbox","title":"Transportation","required":true,"enum":["Vehicle","Airplane","Cruise"]}}},
                     null,
                     null,
-                    "Boolean supporting radio and checkbox type. Must define `format` and `enum` fields."]
+                    "Boolean supporting radio and checkbox type. Must define `format` and `enum` fields."],
                 ["Additional input type format",
                     {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"password":{"title":"Password","type":"string","format":"password","description":"Password field would have the text masked.","required":true},"email":{"title":"Email","type":"string","format":"email","description":"Email field would need to follow the format of name@domain.com in order to pass the validation.","required":true},"date":{"title":"Date","type":"string","format":"date","description":"Use the date picker to pick the date.","required":true},"time":{"title":"Time","type":"string","format":"time","description":"Use the time picker to pick the time.","required":true}}},
                     null,

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -885,6 +885,9 @@ if (typeof brutusin === "undefined") {
                     if (object.length === 0) {
                         return null;
                     }
+                    if (s.format === "checkbox") {
+                        return object;
+                    }
                     var clone = new Array();
                     for (var i = 0; i < object.length; i++) {
                         clone[i] = removeEmptiesAndNulls(object[i], s.items);
@@ -1330,6 +1333,19 @@ if (typeof brutusin === "undefined") {
                     value = input.checked;
                     if (!value) {
                         value = false;
+                    }
+                } else if (schema.format === "checkbox") {
+                    var checkboxValue = [];
+                    for (var i = 0; i < input.childElementCount; i++) {
+                        if (input.childNodes[i].tagName === "INPUT" && input.childNodes[i].checked) {
+                            checkboxValue.push(input.childNodes[i].value);
+                        }
+                    }
+                    if (checkboxValue.length !== 0) {
+                        value = checkboxValue;
+                    }
+                    else {
+                        value = null;
                     }
                 } else if (input.tagName.toLowerCase() === "select") {
                     if (input.value === "true") {


### PR DESCRIPTION
**Description**: Add `getData()` support for checkbox to retrieve values.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/69d1f1ce-5c3a-41cb-bc84-7df03fc8eb03)
_After clicking the `getData()` button, the data return empty values eventhough Dog and Cat is selected._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/98dd71fe-b1d1-4cd9-8659-efebf7ca0bb8)
_After clicking the `getData()` button, now it would retrieves the selected values_
