### PR TITLE
Enhancement: Add initial data support for checkbox

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -407,8 +407,12 @@ if (typeof brutusin === "undefined") {
                     label.htmlFor = s.enum[i];
                     var labelText = document.createTextNode(s.enum[i]);
                     appendChild(label, labelText);
-                    if (value && s.enum[i] === value) {
-                        checkbox.checked = true;
+                    if (value) {
+                        for (var j = 0; j < value.length; j++) {
+                            if (s.enum[i] === value[j]) {
+                                checkbox.checked = true;
+                            }
+                        }
                     }
                     if (s.readOnly) {
                         checkbox.disabled = true;


### PR DESCRIPTION
**Description**: Add initial data support for checkbox so data can be initialized upon generation of the form. Below is the schema used:
Schema:
```
{
  "$schema": "http://json-schema.org/draft-03/schema#",
  "type": "object",
  "properties": {
    "animal": {
      "type": "boolean",
      "title": "Animals",
      "format": "checkbox",
      "enum": ["Cat", "Dog", "Mouse"],
      "description": "Checkbox with initial data"
    }
  }
}
```

Initial data:
```
{
  "animal": ["Dog", "Mouse"]
}
```

**Pic before changes:**
![image](https://github.com/brutusin/json-forms/assets/137158566/3854bd1c-5c64-4c42-a121-d07439a58660)
![image](https://github.com/brutusin/json-forms/assets/137158566/7ae628a7-99f6-42e3-9ace-73da3f6fcb7d)
_Initial data is defined but doesn’t reflects on the generated form._

**Pic after changes:**

![image](https://github.com/brutusin/json-forms/assets/137158566/ed1a6149-4f9f-4437-8d6a-3bbab09ed2b3)
_Now the value defined in the initial data schema is ticked._
