### PR TITLE
Enhancement: Replace glyphicon with bootstrap-icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <script src="src/js/brutusin-json-forms-bootstrap.js"></script>
         <script lang="javascript">
             var BrutusinForms = brutusin["json-forms"];
-            BrutusinForms.bootstrap.addFormatDecorator("inputstream", "file", "glyphicon-search", null, function (element) {
+            BrutusinForms.bootstrap.addFormatDecorator("inputstream", "file", "bi-search", null, function (element) {
                 alert("user callback on element " + element)
             });
             BrutusinForms.bootstrap.addFormatDecorator("color", "color");
@@ -92,7 +92,7 @@
                     null,
                     "`textarea` rendering for `string` schemas"],
                 ["Custom string formats",
-                    {"$schema": "http://json-schema.org/draft-03/schema#", "type": "object", "properties": {"file": {"type": "string", "format": "inputstream", "description": "Using a custom format decorator with **glyphicon** via `addFormatDecorator(...)` of the bootstrap extension script"}, "color": {"type": "string", "format": "color", "description": "Using a custom format decorator via `addFormatDecorator(...)` of the bootstrap extension script"}, "date": {"type": "string", "format": "date", "description": "Using a custom format decorator with glyphicon via `addFormatDecorator(...)` of the bootstrap extension script"}}},
+                    {"$schema": "http://json-schema.org/draft-03/schema#", "type": "object", "properties": {"file": {"type": "string", "format": "inputstream", "description": "Using a custom format decorator with **bootstrapIcon** via `addFormatDecorator(...)` of the bootstrap extension script"}, "color": {"type": "string", "format": "color", "description": "Using a custom format decorator via `addFormatDecorator(...)` of the bootstrap extension script"}, "date": {"type": "string", "format": "date", "description": "Using a custom format decorator with Bootstrap Icon via `addFormatDecorator(...)` of the bootstrap extension script"}}},
                     null,
                     null,
                     "Input types can be chosen for custom `string` schema formats via `BrutusinForms.bootstrap.addFormatDecorator(...)`. See current registered decorators at this page source code."],
@@ -310,7 +310,6 @@
                 codeMirrors[selectedTab].setValue(inputString[selectedTab]);
             }
             );
-
         </script>
     </body>
 </html> 

--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -33,13 +33,13 @@ a, a:hover, a:visited, a:active, a:focus {
 }
 .loading-icon{
     position: absolute;
-    top:14px;
+    top:2px;
     left:50%;
     z-index : 11;
 }
 .loading-icon-select{
     position: absolute;
-    top:14px;
+    top:2px;
     left:50%;
     z-index : 11;
 }
@@ -49,9 +49,13 @@ a, a:hover, a:visited, a:active, a:focus {
     left:3px;
     z-index : 11;
 }
-.glyphicon-refresh-animate {
-    animation: spin .7s infinite linear;
-    -webkit-animation: spin2 .7s infinite linear;
+
+.form-inline label {
+    justify-content: end;
+}
+
+.accordion>.card {
+    overflow: unset;
 }
 
 @-webkit-keyframes spin2 {

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -39,7 +39,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                 element.className += " form-control";
             } else if (tagName === "button") {
                 if (element.className === "remove") {
-                    element.className += " glyphicon glyphicon-remove";
+                    element.className += " bi bi-x";
                     while (element.firstChild) {
                         element.removeChild(element.firstChild);
                     }
@@ -89,12 +89,12 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
             var tagName = element.tagName.toLowerCase();
             if (tagName === "label" || tagName === "button") {
                 if (element.title) {
-                    var helpLink = document.createElement("a");
+                    var helpLink = document.createElement("i");
                     helpLink.setAttribute("style", "outline: 0; text-decoration: none; margin-left: 2px;");
                     helpLink.setAttribute("tabIndex", -1);
-                    helpLink.className = "glyphicon glyphicon-info-sign"
+                    helpLink.className = "bi bi-info-circle-fill"
                     helpLink.setAttribute("data-toggle", "popover");
-                    helpLink.setAttribute("data-trigger", "focus");
+                    helpLink.setAttribute("data-trigger", "hover");
                     if ("undefined" === typeof markdown) {
                         helpLink.setAttribute("data-content", element.title);
                     } else {
@@ -110,7 +110,12 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                         container: 'body',
                         html: !("undefined" === typeof markdown)
                     });
-                    element.parentNode.appendChild(helpLink);
+                    if (tagName === "label") {
+                        element.appendChild(helpLink);
+                    }
+                    else if (tagName === "button") {
+                        element.parentNode.appendChild(helpLink);
+                    }
                 }
             }
         }
@@ -155,7 +160,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     });
     BrutusinForms.bootstrap = new Object();
 // helper button for string (with format) fields
-    BrutusinForms.bootstrap.addFormatDecorator = function (format, inputType, glyphicon, titleDecorator, cb) {
+    BrutusinForms.bootstrap.addFormatDecorator = function (format, inputType, bootstrapIcon, titleDecorator, cb) {
         BrutusinForms.addDecorator(function (element, schema) {
             if (element.tagName) {
                 var tagName = element.tagName.toLowerCase();
@@ -163,7 +168,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                     if (inputType) {
                         element.type = inputType;
                     }
-                    if (glyphicon) {
+                    if (bootstrapIcon) {
                         var parent = element.parentNode;
                         var table = document.createElement("table");
                         table.setAttribute("style", "border:none;margin:0");
@@ -179,7 +184,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                         tr.appendChild(td);
                         td.setAttribute("style", "padding:0");
                         var searchButton = document.createElement("button");
-                        searchButton.className = "btn btn-default glyphicon " + glyphicon;
+                        searchButton.className = "btn btn-default bi " + bootstrapIcon;
                         searchButton.onclick = function () {
                             cb(element);
                         };
@@ -207,7 +212,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                 element.parentNode.style.position = "relative";
                 loading = document.createElement("span");
                 loading.id = loadingId;
-                loading.className = "glyphicon glyphicon-refresh glyphicon-refresh-animate";
+                loading.className = "spinner-border";
                 if (tagName === "select") {
                     loading.className += " loading-icon-select";
                 } else if (element.type === "checkbox") {


### PR DESCRIPTION
**Description**: Glyphicon is being used in bootstrap version 3 and below. Bootstrap 4 and above no longer supports Glyphicon. Hence the replacement on the glyphicon to bootstrap-icons with more fresh and modern look icons.

**Pic before changes:**
 ![image](https://github.com/saicheck2233/json-forms/assets/137158566/97d6f9f4-d618-4992-95fb-1aa5249723b5)
**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/71a91ed6-2991-4ba1-8f03-623f199f41de)
_Loading icon changes._

***

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/63959bf1-e16e-42f1-aa36-39ed092d20ef)
**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/a1dced42-e588-40ff-90d5-e0cc72cf05b6)
_Information icon changes._

***

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/0b4682cf-75f4-4bbe-b561-db373ab33c74)
**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/c2c9f4e3-8857-40e5-84e7-b098b0d06277)
_Search icon changes._
