### PR TITLE
UI: Add collapsible and class name examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,12 +120,24 @@
                 {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"radio1":{"type":"boolean","format":"radio","title":"Animal","required":true,"enum":["Dog","Cat","Bird"]},"checkbox":{"type":"boolean","format":"checkbox","title":"Transportation","required":true,"enum":["Vehicle","Airplane","Cruise"]}}},
                     null,
                     null,
-                    "Boolean supporting radio and checkbox type. Must define `format` and `enum` fields."]
+                    "Boolean supporting radio and checkbox type. Must define `format` and `enum` fields."],
                 ["Additional input type format",
                     {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"password":{"title":"Password","type":"string","format":"password","description":"Password field would have the text masked.","required":true},"email":{"title":"Email","type":"string","format":"email","description":"Email field would need to follow the format of name@domain.com in order to pass the validation.","required":true},"date":{"title":"Date","type":"string","format":"date","description":"Use the date picker to pick the date.","required":true},"time":{"title":"Time","type":"string","format":"time","description":"Use the time picker to pick the time.","required":true}}},
                     null,
                     null,
-                    "Additional input type format such as `password`, `email`, `date` and `time`."]
+                    "Additional input type format such as `password`, `email`, `date` and `time`."],
+                ["Collapsible form",
+                    {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","collapsible":true,"title":"Collapsible Form","properties":{"username":{"title":"Username","type":"string","description":"Username","required":true},"password":{"title":"Password","type":"string","format":"password","required":true}}},
+                    null,
+                    null,
+                    "Collapsible form. Must put at the parent level with the `collapsible` field, `title` field is optional."
+                ],
+                ["Custom class Name",
+                {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"username":{"title":"Username","type":"string","description":"The class name is applied in this form field.","required":true,"class":"your-class-name-here"}}},
+                    null,
+                    null,
+                    "Custom class name is supported. Add the `class` field and the class name and it shall apply to that form field."
+                ]
             ];
 
             var selectedTab = "schema";


### PR DESCRIPTION
**Description**: Add the collapsible form example and custom class name example into the website demo.

**Changes**:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/2073a363-3d58-4a43-a7f1-498925ba1954)
![image](https://github.com/saicheck2233/json-forms/assets/137158566/1ac247cf-236e-4752-aa34-0fe9ff5fe127)
_Collapsible form demonstration._

![image](https://github.com/saicheck2233/json-forms/assets/137158566/fc7024e4-3994-4840-abdd-3e61b2f49093)
_Custom class name demonstration._
