### PR TITLE
UI: Add a registration form example

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,14 @@
                     {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"password":{"title":"Password","type":"string","format":"password","description":"Password field would have the text masked.","required":true},"email":{"title":"Email","type":"string","format":"email","description":"Email field would need to follow the format of name@domain.com in order to pass the validation.","required":true},"date":{"title":"Date","type":"string","format":"date","description":"Use the date picker to pick the date.","required":true},"time":{"title":"Time","type":"string","format":"time","description":"Use the time picker to pick the time.","required":true}}},
                     null,
                     null,
-                    "Additional input type format such as `password`, `email`, `date` and `time`."]
+                    "Additional input type format such as `password`, `email`, `date` and `time`."],
+                [
+                    "Registration form example",
+                    {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"name":{"title":"Full Name","required":true,"type":"string"},"username":{"title":"Username","type":"string","required":true,"minLength":6,"maxLength":20},"password":{"title":"Password","type":"string","format":"password","required":true,"description":"Password must contains at least 1 lowercase, 1 uppercase, 1 number and 1 special character with length equals or more than 8","pattern":"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$"},"email":{"title":"Email Address","type":"string","format":"email","required":true,"description":"Email has a default Regex pattern which validates against `name@domain.com` format. Add `pattern` field for custom pattern."},"gender":{"title":"Gender","type":"boolean","enum":["Male","Female","Prefer not to reveal"],"format":"radio","required":true},"dob":{"title":"Birthday","type":"string","format":"date"},"subscription":{"title":"Subscribe to newsletter","type":"boolean","required":true}}},
+                    null,
+                    null,
+                    "This is a registration form example. Note that the `pattern` field uses Regex, if you have `\\` backslash, remember to use double `\\\\` backslash to escape it or else the Regex won't work."
+                ]
             ];
 
             var selectedTab = "schema";


### PR DESCRIPTION
**Description**: Add a registration form example as a template so that others could use it and make changes according to their needs.

**Changes**:
![image](https://github.com/saicheck2233/json-forms/assets/137158566/38573ad7-20a2-48bb-8539-3c7e4178f834)
_Schema used to create the registration form._
 
![image](https://github.com/saicheck2233/json-forms/assets/137158566/b00cf46a-92ef-424e-830b-931383fbab3a)
_Generated registration form._
