### PR TITLE
Bug: Fix the error message not appearing when there is an error in the schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,17 +167,17 @@
                 $("#jsonAlert").hide();
                 try {
                     message = "The was a syntax error in the schema JSON";
-                    tabId = "schema";
+                    tabId = "schema-tab";
                     eval("schema=" + inputString.schema);
                     if (inputString.data) {
                         message = "The was a syntax error in the initial data JSON";
-                        tabId = "data";
+                        tabId = "data-tab";
                         eval("data=" + inputString.data);
                     } else {
                         data = null;
                     }
                     if (inputString.resolver) {
-                        tabId = "resolver";
+                        tabId = "resolver-tab";
                         message = "The was a syntax error in the resolver code";
                         eval("resolver=" + inputString.resolver);
                         if ("function" !== typeof resolver) {
@@ -186,7 +186,7 @@
                     }
                 } catch (err) {
                     document.getElementById('error-message').innerHTML = message + (err ? ". " + err : "");
-                    $('[href=#' + tabId + ']').tab('show');
+                    $('button[id=' + tabId + ']').tab('show');
                     $("#jsonAlert").show();
                     return;
                 }
@@ -254,8 +254,8 @@
                                 <div role="tabpanel" class="tab-pane fade " id="data" role="tabpanel" aria-labelledby="data-tab"></div>
                                 <div role="tabpanel" class="tab-pane fade " id="resolver" role="tabpanel" aria-labelledby="resolver-tab"></div>
                             </div>
-                            <div class="alert alert-danger in" role="alert" id="jsonAlert" style="display:none">
-                                <a href="#" onclick='$("#jsonAlert").hide();' class="close" >&times;</a>
+                            <div class="alert alert-danger in" role="alert" id="jsonAlert" style="display:none; margin-top:1rem;">
+                                <span onclick='$("#jsonAlert").hide();' class="close" >&times;</span>
                                 <strong>Error!</strong> <span id="error-message"></span>
                             </div>
                             <button class="btn btn-primary mt-3" onclick="generateForm()">Create form</button>

--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -190,3 +190,6 @@ blockquote {
     display: flex;
     padding: 6px 0;
 }
+.close {
+    cursor: pointer;
+}


### PR DESCRIPTION
**Description**: Previously when there is an error in the JSON syntax, there would be an alert box appeared bottom of the schema tab notifying the user there is an error. But the alert box is missing after the bootstrap update.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/aaa40c14-f025-45fb-a679-d1ebb488aa4b)
_A missing comma (,) in the JSON schema would throw a syntax error when clicking the “Create form” button but the alert box doesn’t come out._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/30dc50a3-ac29-4301-835a-293a90203fd3)
_Now upon clicking the “Create form” button, the alert box message would pop out._
