### PR TITLE
Bug: Fix text field not showing red border when there is validation error

### DIFF
--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -245,7 +245,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.onResolutionFinished = BrutusinForms.bootstrap.hideLoading;
 
     BrutusinForms.onValidationSuccess = function (element) {
-        element.parentNode.className = element.parentNode.className.replace(" has-error", "");
+        element.className = element.className.replace(" is-invalid", "");
     }
     BrutusinForms.onValidationError = function (element, message) {
 
@@ -271,8 +271,8 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
             }
 
             element.title = BrutusinForms.messages["validationError"];
-            if (!element.parentNode.className.includes("has-error")) {
-                element.parentNode.className += " has-error";
+            if (!element.className.includes("is-invalid")) {
+                element.className += " is-invalid";
             }
             element.focus();
             $(element).popover({
@@ -289,7 +289,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                     element.setAttribute("data-trigger", dataTrigger);
                     element.setAttribute("data-content", dataContent);
                 } else {
-                    $(element).popover('destroy');
+                    $(element).popover('dispose');
                     element.removeAttribute("data-toggle");
                     element.removeAttribute("data-trigger");
                     element.removeAttribute("data-content");

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -263,6 +263,13 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.onResolutionFinished = BrutusinForms.bootstrap.hideLoading;
 
     BrutusinForms.onValidationSuccess = function (element) {
+        if (element.tagName === "DIV" && element.childElementCount !== 0) {
+            for (var i = 0; i < element.childElementCount; i++) {
+                if (element.childNodes[i].tagName === "INPUT") {
+                    element.childNodes[i].className = element.childNodes[i].className.replace(" is-invalid", "");
+                }
+            }
+        }
         element.className = element.className.replace(" is-invalid", "");
     }
     BrutusinForms.onValidationError = function (element, message) {


### PR DESCRIPTION
**Description**: In normal UI/UX experience, when there is an validation error on the text field, it should be highlighted in red to indicate there is an error. Currently the text field is not highlighted.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/92c67973-66d6-439c-bfbd-947eb30ae9d3)
_There is no red border on the text field when there is a validation error._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/7278274d-180a-4255-826e-c1c706364dd7)
_Now the input text field has a red border signifies that this field has a validation error._
