### PR TITLE
UI: Beautify the generated form

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -685,21 +685,24 @@ if (typeof brutusin === "undefined") {
                 for (var prop in s.properties) {
                     var tr = document.createElement("tr");
                     var td1 = document.createElement("td");
-                    td1.className = "prop-name";
+                    td1.className = "form-group row";
+                    var divLabel = document.createElement("div");
+                    divLabel.className = "col-md-2";
                     var propId = id + "." + prop;
                     var propSchema = getSchema(getSchemaId(propId));
-                    var td2 = document.createElement("td");
-                    td2.className = "prop-value";
+                    var divValue = document.createElement("div");
+                    divValue.className = "col-md-10";
 
                     appendChild(tbody, tr, propSchema);
                     appendChild(tr, td1, propSchema);
-                    appendChild(tr, td2, propSchema);
+                    appendChild(td1, divLabel, propSchema);
+                    appendChild(td1, divValue, propSchema);
                     var pp = createStaticPropertyProvider(prop);
                     var propInitialValue = null;
                     if (value) {
                         propInitialValue = value[prop];
                     }
-                    render(td1, td2, propId, current, pp, propInitialValue);
+                    render(divLabel, divValue, propId, current, pp, propInitialValue);
                 }
             }
             var usedProps = [];


### PR DESCRIPTION
**Description**: Follow Bootstrap v4 standard and beautify the form to make it looks more loosen instead of compact the fields and labels altogether.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/dd61e3f3-6628-42df-947e-da7a0c3206c8)
_The initial form looks compact and cluttered._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/73b3b123-ad51-4b1d-8c5e-63cda9bbfc49)
_The new form now looks more loosen and well arranged._
