### PR TITLE
UI: Change the file input UI looks

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <script src="lib/codemirror/codemirror.js"></script>
         <script src="lib/codemirror/codemirror-javascript.js"></script>
         <script src="lib/markdown.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bs-custom-file-input/dist/bs-custom-file-input.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.14/js/bootstrap-select.min.js" integrity="sha512-CJXg3iK9v7yyWvjk2npXkQjNQ4C1UES1rQaNB7d7ZgEVX2a8/2BmtDmtTclW4ial1wQ41cU34XPxOw+6xJBmTQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.14/js/i18n/defaults-en_US.min.js" integrity="sha512-29UqgjaGxHyaEq1vJw4Q20iw6gBOMJDEUud/MNhXrJK6avCLukZ3eQf93AG7dywglnx21FoBvmHHBzP32O2YUw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <!--
@@ -92,7 +93,7 @@
                     null,
                     "`textarea` rendering for `string` schemas"],
                 ["Custom string formats",
-                    {"$schema": "http://json-schema.org/draft-03/schema#", "type": "object", "properties": {"file": {"type": "string", "format": "inputstream", "description": "Using a custom format decorator with **bootstrapIcon** via `addFormatDecorator(...)` of the bootstrap extension script"}, "color": {"type": "string", "format": "color", "description": "Using a custom format decorator via `addFormatDecorator(...)` of the bootstrap extension script"}, "date": {"type": "string", "format": "date", "description": "Using a custom format decorator with Bootstrap Icon via `addFormatDecorator(...)` of the bootstrap extension script"}}},
+                {"$schema":"http://json-schema.org/draft-03/schema#","type":"object","properties":{"customFileType":{"type":"string","format":"inputstream","description":"Using a custom format decorator with **bootstrapIcon** via `addFormatDecorator(...)` of the bootstrap extension script"},"defaultFileType":{"type":"string","media":true,"description":"This is the default file type UI"},"color":{"type":"string","format":"color","description":"Using a custom format decorator via `addFormatDecorator(...)` of the bootstrap extension script"},"date":{"type":"string","format":"date","description":"Using a custom format decorator with Bootstrap Icon via `addFormatDecorator(...)` of the bootstrap extension script"}}},
                     null,
                     null,
                     "Input types can be chosen for custom `string` schema formats via `BrutusinForms.bootstrap.addFormatDecorator(...)`. See current registered decorators at this page source code."],

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -26,6 +26,10 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     console.warn("Include bootstrap-select.js (https://github.com/silviomoreto/bootstrap-select) to turn native selects into bootstrap components");
 }
 
+if ("undefined" === typeof bsCustomFileInput && window.console) {
+    console.warn("Include bs-custom-file-input.min.js (https://github.com/Johann-S/bs-custom-file-input) to have a more interative UI for file selection");
+}
+
 (function () {
     var BrutusinForms = brutusin["json-forms"];
 
@@ -33,7 +37,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.addDecorator(function (element, schema) {
         if (element.tagName) {
             var tagName = element.tagName.toLowerCase();
-            if (tagName === "input" && (element.type !== "checkbox" && element.type !== "radio" && element.type !== "range") || tagName === "textarea") {
+            if (tagName === "input" && (element.type !== "file" && element.type !== "checkbox" && element.type !== "radio" && element.type !== "range") || tagName === "textarea") {
                 element.className += " form-control";
             } else if (tagName === "select") {
                 element.className += " form-control";
@@ -45,6 +49,19 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                     }
                 }
                 element.className += " btn btn-warning btn-sm";
+            } else if (tagName === "input" && element.type === "file") {
+                element.className += " custom-file-input";
+                var label = document.createElement("label");
+                label.className = "custom-file-label";
+                label.innerHTML = "Choose file";
+                label.setAttribute("for", element.id);
+                element.parentNode.classList.add("custom-file");
+                element.parentNode.appendChild(label);
+                if ("undefined" !== typeof bsCustomFileInput || "undefined" !== typeof $) {
+                    $(document).ready(function () {
+                        bsCustomFileInput.init();
+                    });
+                }
             }
         }
     });


### PR DESCRIPTION
**Description**: The current file input type UI looks is quite old fashioned and it is the default DOM structure. Added 3rd party library [bs-custom-file-input](https://github.com/Johann-S/bs-custom-file-input) to change the looks and feel. Drag and drop of the file is also supported.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/42051271-a81e-4a92-81ad-c49bd2a050c1)
_Old file type UI looks_

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/59f362ad-6f4a-4c64-b06e-80035eb055c8)
_New file type UI looks_