### PR TITLE
UI: Change validation error layout

### DIFF
--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -202,3 +202,6 @@ blockquote {
 .close {
     cursor: pointer;
 }
+.form-check.is-invalid .form-check-label {
+    color: #dc3545;
+}

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -263,70 +263,21 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.onResolutionFinished = BrutusinForms.bootstrap.hideLoading;
 
     BrutusinForms.onValidationSuccess = function (element) {
-        if (element.tagName === "DIV" && element.childElementCount !== 0) {
-            for (var i = 0; i < element.childElementCount; i++) {
-                if (element.childNodes[i].tagName === "INPUT") {
-                    element.childNodes[i].className = element.childNodes[i].className.replace(" is-invalid", "");
-                }
-            }
-        }
         element.className = element.className.replace(" is-invalid", "");
     }
     BrutusinForms.onValidationError = function (element, message) {
 
-        setTimeout(function () {
-            if (element.tagName === "DIV" && element.childElementCount !== 0) {
-                for (var i = 0; i < element.childElementCount; i++) {
-                    if (element.childNodes[i].tagName === "INPUT") {
-                        element = element.childNodes[i];
-                        break;
-                    }
-                }
-            }
-            var dataToggle = element.getAttribute("data-toggle");
-            var dataTrigger = element.getAttribute("data-trigger");
-            var dataContent = element.getAttribute("data-content");
-            var title = element.title;
-            element.setAttribute("data-toggle", "popover");
-            element.setAttribute("data-trigger", "manual");
-            if ("undefined" === typeof markdown) {
-                element.setAttribute("data-content", message);
-            } else {
-                element.setAttribute("data-content", markdown.toHTML(message));
-            }
-
-            element.title = BrutusinForms.messages["validationError"];
-            if (!element.className.includes("is-invalid")) {
-                element.className += " is-invalid";
-            }
-            element.focus();
-            $(element).popover({
-                placement: 'top',
-                container: 'body',
-                html: true
-            });
-            $(element).popover("show");
-            var onblur = element.onblur;
-            element.onblur = function (e) {
-                if (dataToggle) {
-                    $(element).popover('hide');
-                    element.setAttribute("data-toggle", dataToggle);
-                    element.setAttribute("data-trigger", dataTrigger);
-                    element.setAttribute("data-content", dataContent);
-                } else {
-                    $(element).popover('dispose');
-                    element.removeAttribute("data-toggle");
-                    element.removeAttribute("data-trigger");
-                    element.removeAttribute("data-content");
-                }
-
-                element.onblur = onblur;
-                element.title = title;
-                if (onblur) {
-                    onblur();
-                }
-            }
-        },
-                200);
+        var div = document.createElement("div");
+        div.className = "invalid-feedback";
+        if ("undefined" === typeof markdown) {
+            div.innerHTML = message;
+        } else {
+            div.innerHTML = markdown.toHTML(message);
+        }
+        element.parentNode.appendChild(div);
+        element.title = BrutusinForms.messages["validationError"];
+        if (!element.className.includes("is-invalid")) {
+            element.className += " is-invalid";
+        }
     }
 }());


### PR DESCRIPTION
**Description**: The current validation error is a popover on top of the field element and sometimes the placement is not consistent. Furthermore the popover might not display each of the field that is having error. In the new UI update, it would change to a error description underneath the erroneous field, which also adhere to Bootstrap v4 standard.

**Pic before changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/1cf64257-a752-4683-9857-cb754d35ded8)
_Display validation error message is done on popover on the field, and certain cases some field doesn’t have popover due to Javascript error._

**Pic after changes:**
![image](https://github.com/saicheck2233/json-forms/assets/137158566/27303cee-5ffe-4e0a-a9d7-30cabeeae4b7)
_Now display the error message under the affected text field, which looks more cleaner and organised._